### PR TITLE
mockupdb 1.8.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,13 +32,9 @@ test:
   imports:
     - mockupdb
   requires:
-    # added constraint of pymongo<4 as the tests used functions
-    # removed in pymongo 4.0
+    # Add a constraint of pymongo<4 as the tests use functions removed
+    # in pymongo 4.0
     - pymongo >=3,<4  # [not (py>311 or (py>310 and osx and arm64) )]
-    # XXX even though we're not running the tests for py>311, we need
-    # *a* mongodb, which has a vendored bson, which mockupdb requires
-    # (for pip check).
-    - pymongo >=3     # [py>311 or (py>=310 and (osx and arm64))]
     - pip
     - pytest
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - wheel
   run:
     - python
+    - pymongo >=3
 
 test:
   source_files:
@@ -31,6 +32,8 @@ test:
   imports:
     - mockupdb
   requires:
+    # added constraint of pymongo<4 as the tests used functions
+    # removed in pymongo 4.0
     - pymongo >=3,<4  # [not (py>311 or (py>310 and osx and arm64) )]
     # XXX even though we're not running the tests for py>311, we need
     # *a* mongodb, which has a vendored bson, which mockupdb requires

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   sha256: "{{ sha256 }}"
 
 build:
+  skip: True  # [py<34]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv --no-build-isolation
 
@@ -24,13 +25,17 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - mockupdb
   requires:
-    - pymongo >=3
+    - pymongo >=3,<4
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests
 
 about:
   home: https://github.com/ajdavis/mongo-mockup-db

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   # No mongodb on s390x
   skip: True  # [py<34 or s390x]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv --no-build-isolation
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-build-isolation -vv
 
 requirements:
   host:
@@ -35,7 +35,7 @@ test:
     # XXX even though we're not running the tests for py>311, we need
     # *a* mongodb, which has a vendored bson, which mockupdb requires
     # (for pip check).
-    - pymongo >=3     # [py>311 or (py>=310 and osx and arm64)]
+    - pymongo >=3     # [py>311 or (py>=310 and (osx and arm64))]
     - pip
     - pytest
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
   sha256: "{{ sha256 }}"
 
 build:
-  skip: True  # [py<34]
+  # No mongodb on s390x
+  skip: True  # [py<34 or s390x]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv --no-build-isolation
 
@@ -30,12 +31,16 @@ test:
   imports:
     - mockupdb
   requires:
-    - pymongo >=3,<4
+    - pymongo >=3,<4  # [not py>311]
+    # XXX even though we're not running the tests for py>311, we need
+    # *a* mongodb, which has a vendored bson, which mockupdb requires
+    # (for pip check).
+    - pymongo >=3     # [py>311]
     - pip
     - pytest
   commands:
     - pip check
-    - pytest -v tests
+    - pytest -v tests  # [not py>311]
 
 about:
   home: https://github.com/ajdavis/mongo-mockup-db

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,16 +31,16 @@ test:
   imports:
     - mockupdb
   requires:
-    - pymongo >=3,<4  # [not py>311]
+    - pymongo >=3,<4  # [not (py>311 or (py>310 and osx and arm64) )]
     # XXX even though we're not running the tests for py>311, we need
     # *a* mongodb, which has a vendored bson, which mockupdb requires
     # (for pip check).
-    - pymongo >=3     # [py>311]
+    - pymongo >=3     # [py>311 or (py>=310 and osx and arm64)]
     - pip
     - pytest
   commands:
     - pip check
-    - pytest -v tests  # [not py>311]
+    - pytest -v tests  # [not (py>311 or (py>310 and osx and arm64) )]
 
 about:
   home: https://github.com/ajdavis/mongo-mockup-db

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mockupdb" %}
-{% set version = "1.7.0" %}
-{% set sha256 = "6cdcfdd14e40a11bb01a8972502d3f6c0a96bccfd8774e19385bf3b38b852d63" %}
+{% set version = "1.8.1" %}
+{% set sha256 = "d36d0e5b6445ff9141e34d012fa2b5dfe589847aa1e3ecb8d774074962af944e" %}
 
 package:
   name: "{{ name|lower }}"
@@ -12,13 +12,14 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv --no-build-isolation
 
 requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
 
@@ -27,6 +28,9 @@ test:
     - mockupdb
   requires:
     - pymongo >=3
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/ajdavis/mongo-mockup-db
@@ -34,7 +38,10 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: MongoDB Wire Protocol server library
-  doc_url: http://mockupdb.readthedocs.org/
+  description: |
+    Mock server for testing MongoDB clients and creating MongoDB Wire
+    Protocol servers.
+  doc_url: https://mockupdb.readthedocs.io/
   dev_url: https://github.com/ajdavis/mongo-mockup-db
 
 extra:


### PR DESCRIPTION
mockupdb 1.8.1 

**Destination channel:** Defaults

### Links

- [PKG-5431]
- dev_url:        https://github.com/ajdavis/mongo-mockup-db/tree/1.8.1
- conda_forge:    https://github.com/conda-forge/mockupdb-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/mockupdb/1.8.1
- pypi inspector: https://inspector.pypi.io/project/mockupdb/1.8.1

### Explanation of changes:

- forked from conda-forge
- new version number
- run the tests:
  - note the added constraint of `pymongo<4` as the tests used functions removed in `pymongo` `4.0`
  - plus some dance around which platforms _have_ a `pymongo>=3,<4`


[PKG-5431]: https://anaconda.atlassian.net/browse/PKG-5431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ